### PR TITLE
BSP-145: added class with all endpoints for BSP 2.1 defined

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ plugins {
 apply plugin: 'org.springframework.boot'
 
 group 'uk.gov.hmcts.reform'
-version '0.0.12'
+version '0.0.13'
 
 dependencyUpdates.resolutionStrategy = {
     componentSelection { rules ->

--- a/src/main/java/uk/gov/hmcts/reform/bsp/common/config/BulkScanEndpoints.java
+++ b/src/main/java/uk/gov/hmcts/reform/bsp/common/config/BulkScanEndpoints.java
@@ -1,0 +1,10 @@
+package uk.gov.hmcts.reform.bsp.common.config;
+
+/**
+ * All endpoints required by BSP phase 2.1 that should be implemented to fully support bulk scan process.
+ * */
+public class BulkScanEndpoints {
+    public static final String VALIDATE = "/forms/{form-type}/validate-ocr";
+    public static final String TRANSFORM = "/transform-exception-record";
+    public static final String UPDATE = "/update-case";
+}


### PR DESCRIPTION
One place to define all BSP 2.1 endpoints to re-use across reform.