### PR TITLE
BSP-167: update BulkScanCaseUpdateRequest model (added caseDetails)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ plugins {
 apply plugin: 'org.springframework.boot'
 
 group 'uk.gov.hmcts.reform'
-version '0.0.13'
+version '0.0.14'
 
 dependencyUpdates.resolutionStrategy = {
     componentSelection { rules ->

--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ plugins {
 apply plugin: 'org.springframework.boot'
 
 group 'uk.gov.hmcts.reform'
-version '0.0.14'
+version '0.0.15'
 
 dependencyUpdates.resolutionStrategy = {
     componentSelection { rules ->

--- a/src/main/java/uk/gov/hmcts/reform/bsp/common/model/transformation/output/SuccessfulTransformationResponse.java
+++ b/src/main/java/uk/gov/hmcts/reform/bsp/common/model/transformation/output/SuccessfulTransformationResponse.java
@@ -15,5 +15,5 @@ public class SuccessfulTransformationResponse {
     private final CaseCreationDetails caseCreationDetails;
 
     @JsonProperty("warnings")
-    private final List<String> warnings = new ArrayList<>();
+    @Builder.Default private final List<String> warnings = new ArrayList<>();
 }

--- a/src/main/java/uk/gov/hmcts/reform/bsp/common/model/update/in/BulkScanCaseUpdateRequest.java
+++ b/src/main/java/uk/gov/hmcts/reform/bsp/common/model/update/in/BulkScanCaseUpdateRequest.java
@@ -4,8 +4,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Getter;
 import uk.gov.hmcts.reform.bsp.common.model.transformation.in.ExceptionRecord;
 
-import java.util.Map;
-
 @Getter
 public class BulkScanCaseUpdateRequest {
 

--- a/src/main/java/uk/gov/hmcts/reform/bsp/common/model/update/in/BulkScanCaseUpdateRequest.java
+++ b/src/main/java/uk/gov/hmcts/reform/bsp/common/model/update/in/BulkScanCaseUpdateRequest.java
@@ -10,13 +10,13 @@ import java.util.Map;
 public class BulkScanCaseUpdateRequest {
 
     private final ExceptionRecord exceptionRecord;
-    private final Map<String, Object> caseData;
+    private final CaseDetails caseDetails;
 
     public BulkScanCaseUpdateRequest(
         @JsonProperty("exception_record") ExceptionRecord exceptionRecord,
-        @JsonProperty("case_details") Map<String, Object> caseData
+        @JsonProperty("case_details") CaseDetails caseDetails
     ) {
         this.exceptionRecord = exceptionRecord;
-        this.caseData = caseData;
+        this.caseDetails = caseDetails;
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/bsp/common/model/update/in/CaseDetails.java
+++ b/src/main/java/uk/gov/hmcts/reform/bsp/common/model/update/in/CaseDetails.java
@@ -1,0 +1,26 @@
+package uk.gov.hmcts.reform.bsp.common.model.update.in;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+import lombok.Data;
+
+import java.util.Map;
+
+@Data
+@JsonIgnoreProperties(ignoreUnknown = true)
+@Builder(toBuilder = true)
+public class CaseDetails {
+
+    @JsonProperty("case_data")
+    private Map<String, Object> caseData;
+
+    /**
+     * This field is expected in the future, please see: https://tools.hmcts.net/jira/browse/BPS-968
+     * but we can add it now as we `JsonIgnoreProperties(ignoreUnknown = true)`
+     * */
+    @JsonProperty("id")
+    private String caseId;
+
+    private String state;
+}

--- a/src/main/java/uk/gov/hmcts/reform/bsp/common/model/update/in/CaseUpdateDetails.java
+++ b/src/main/java/uk/gov/hmcts/reform/bsp/common/model/update/in/CaseUpdateDetails.java
@@ -1,4 +1,4 @@
-package uk.gov.hmcts.reform.bsp.common.model.transformation.output;
+package uk.gov.hmcts.reform.bsp.common.model.update.in;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Builder;

--- a/src/main/java/uk/gov/hmcts/reform/bsp/common/model/update/output/SuccessfulUpdateResponse.java
+++ b/src/main/java/uk/gov/hmcts/reform/bsp/common/model/update/output/SuccessfulUpdateResponse.java
@@ -3,7 +3,7 @@ package uk.gov.hmcts.reform.bsp.common.model.update.output;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Builder;
 import lombok.Data;
-import uk.gov.hmcts.reform.bsp.common.model.transformation.output.CaseUpdateDetails;
+import uk.gov.hmcts.reform.bsp.common.model.update.in.CaseUpdateDetails;
 
 import java.util.List;
 

--- a/src/test/java/uk/gov/hmcts/reform/bsp/common/model/validation/out/OcrValidationResultTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bsp/common/model/validation/out/OcrValidationResultTest.java
@@ -17,19 +17,21 @@ public class OcrValidationResultTest {
         assertThat(warningAndErrorMessagesResult.getStatus(), is(ValidationStatus.ERRORS));
 
         OcrValidationResult errorMessagesOnlyResult = OcrValidationResult.builder().addError("Error message").build();
+
         assertThat(errorMessagesOnlyResult.getStatus(), is(ValidationStatus.ERRORS));
     }
 
     @Test
     public void shouldHaveWarningsStatusWhenThereIs_WarningMessage_ButNoErrorMessage() {
         OcrValidationResult warningMessagesOnlyResult = OcrValidationResult.builder().addWarning("Error message").build();
+
         assertThat(warningMessagesOnlyResult.getStatus(), is(ValidationStatus.WARNINGS));
     }
 
     @Test
     public void shouldHaveSuccessStatusWhenThereIs_NoWarningMessage_NorErrorMessage() {
         OcrValidationResult noMessagesResult = OcrValidationResult.builder().build();
+
         assertThat(noMessagesResult.getStatus(), is(SUCCESS));
     }
-
 }


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/BSP-167

Align to current documentation of RBS:

```  CaseDetails:
    type: "object"
    properties:
      case_type_id:
        type: "string"
        description: "ID of the case type"
      case_data:
        type: "object"
        description: "Current version of case data, as returned by CCD"```

https://tools.hmcts.net/confluence/pages/viewpage.action?pageId=1064666568#TechnicalprerequisitesandinformationforServiceon-boardingwithPhase2Bulkscanningforcasecreation.-2.3.4(INPROGRESS)Updateendpointforanexistingcase(basedonOCRdata)

+ added `id` that will be useful in the future, but now is not a mandatory field.