### PR TITLE
BSP-341: fixed bug with null as a value of OCR field

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ plugins {
 apply plugin: 'org.springframework.boot'
 
 group 'uk.gov.hmcts.reform'
-version '0.0.24'
+version '0.0.25'
 
 dependencyUpdates.resolutionStrategy = {
     componentSelection { rules ->

--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ plugins {
 apply plugin: 'org.springframework.boot'
 
 group 'uk.gov.hmcts.reform'
-version '0.0.25'
+version '0.0.26'
 
 dependencyUpdates.resolutionStrategy = {
     componentSelection { rules ->

--- a/src/main/java/uk/gov/hmcts/reform/bsp/common/mapper/GenericMapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/bsp/common/mapper/GenericMapper.java
@@ -25,7 +25,7 @@ public class GenericMapper {
 
     public static Optional<String> getValueFromOcrDataFields(String fieldName, List<OcrDataField> ocrDataFields) {
         return ocrDataFields.stream()
-            .filter(f -> f.getName().equals(fieldName))
+            .filter(f -> f.getName().equals(fieldName) && f.getValue() != null)
             .map(OcrDataField::getValue)
             .findFirst();
     }

--- a/src/test/java/uk/gov/hmcts/reform/bsp/common/mapper/GenericMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bsp/common/mapper/GenericMapperTest.java
@@ -18,15 +18,16 @@ import static uk.gov.hmcts.reform.bsp.common.mapper.GenericMapper.getValueFromOc
 
 public class GenericMapperTest {
 
-    public static final String LINE_1 = "102 Petty France";
-    public static final String TOWN = "London";
-    public static final String POSTCODE = "SW8 2PX";
-    public static final String COUNTY = "Greater London";
-    public static final String COUNTRY = "UK";
-
     @Test
     public void getValueFromOcrDataFieldsGetsEmptyWhenEmptyList() {
         List<OcrDataField> input = Collections.emptyList();
+
+        assertThat(getValueFromOcrDataFields("myField", input), is(Optional.empty()));
+    }
+
+    @Test
+    public void getValueFromOcrDataFieldsGetsEmptyWhenValueOfTheFoundElementIsNull() {
+        List<OcrDataField> input = asList(new OcrDataField("myField", null));
 
         assertThat(getValueFromOcrDataFields("myField", input), is(Optional.empty()));
     }
@@ -78,7 +79,7 @@ public class GenericMapperTest {
             input
         );
 
-        Map<String, Object> result = (Map)caseData.get("extractedObject");
+        Map<String, Object> result = (Map) caseData.get("extractedObject");
 
         assertThat(result.size(), is(2));
         assertThat(result.get("parentObjectField1"), is("ok"));
@@ -104,7 +105,8 @@ public class GenericMapperTest {
             input
         );
 
-        Map<String, Object> result = (Map)caseData.get("extractedObject");
+        Map<String, Object> result = (Map) caseData.get("extractedObject");
+
         assertThat(result.size(), is(1));
         assertThat(result.get("FieldDefinedTwice"), is("fine"));
     }
@@ -128,7 +130,7 @@ public class GenericMapperTest {
             input
         );
 
-        Map<String, Object> result = (Map)caseData.get("extractedObject");
+        Map<String, Object> result = (Map) caseData.get("extractedObject");
 
         assertThat(result.size(), is(1));
         assertThat(result.get("parentObjectField1"), is("ok"));


### PR DESCRIPTION
### Logs ###
https://portal.azure.com/#blade/AppInsightsExtension/DetailsV2Blade/DataModel/%7B%22eventId%22%3A%22e3440359-6eb6-11ea-aeb4-8fe7463ac6dd%22%2C%22timestamp%22%3A%222020-03-25T16%3A37%3A12.315Z%22%2C%22cacheId%22%3A%220bf3e540-41e5-40ca-ac39-2f54c06808e6%22%2C%22eventTable%22%3A%22exceptions%22%2C%22timeContext%22%3A%7B%22durationMs%22%3A1800000%2C%22endTime%22%3A%222020-03-25T16%3A40%3A00.000Z%22%2C%22createdTime%22%3A%222020-03-25T16%3A42%3A43.708Z%22%2C%22isInitialTime%22%3Afalse%2C%22grain%22%3A1%2C%22useDashboardTimeRange%22%3Afalse%7D%7D/ComponentId/%7B%22Name%22%3A%22bulk-scan-aat%22%2C%22SubscriptionId%22%3A%221c4f0704-a29e-403d-b719-b90c34ef14c9%22%2C%22ResourceGroup%22%3A%22bulk-scan-aat%22%7D


### Change description ###
```Inner exception java.lang.NullPointerException handled at org.springframework.web.servlet.FrameworkServlet.processRequest:
   at java.util.Objects.requireNonNull (Objects.java203)
   at java.util.Optional.<init> (Optional.java96)
   at java.util.Optional.of (Optional.java108)
   at java.util.stream.FindOps$FindSink$OfRef.get (FindOps.java193)
   at java.util.stream.FindOps$FindSink$OfRef.get (FindOps.java190)
   at java.util.stream.FindOps$FindOp.evaluateSequential (FindOps.java152)
   at java.util.stream.AbstractPipeline.evaluate (AbstractPipeline.java234)

--- THIS IS CAUSED BY NULL AS VALUE IN OcrDataField: ---
   at java.util.stream.ReferencePipeline.findFirst (ReferencePipeline.java464)    at uk.gov.hmcts.reform.bsp.common.mapper.GenericMapper.getValueFromOcrDataFields (GenericMapper.java30)
   at uk.gov.hmcts.reform.bsp.common.mapper.GenericMapper.mapIfSourceExists 
```

**Does this PR introduce a breaking change?** (check one with "x")

```
[x] Yes
[ ] No
```

