### PR TITLE
BSP-356: added AddressLine2 key to address mapping

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ plugins {
 apply plugin: 'org.springframework.boot'
 
 group 'uk.gov.hmcts.reform'
-version '0.0.29'
+version '0.0.30'
 
 dependencyUpdates.resolutionStrategy = {
     componentSelection { rules ->

--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ plugins {
 apply plugin: 'org.springframework.boot'
 
 group 'uk.gov.hmcts.reform'
-version '0.0.28'
+version '0.0.29'
 
 dependencyUpdates.resolutionStrategy = {
     componentSelection { rules ->

--- a/src/main/java/uk/gov/hmcts/reform/bsp/common/mapper/AddressMapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/bsp/common/mapper/AddressMapper.java
@@ -4,6 +4,7 @@ import com.google.common.collect.ImmutableMap;
 import org.apache.commons.lang3.StringUtils;
 import uk.gov.hmcts.reform.bsp.common.model.shared.in.OcrDataField;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -12,24 +13,30 @@ import static uk.gov.hmcts.reform.bsp.common.mapper.GenericMapper.addMappingsTo;
 public class AddressMapper {
 
     public static void applyMappings(
-            String prefix,
-            String parentField,
-            List<OcrDataField> ocrDataFields,
-            Map<String, Object> modifiedMap) {
+        String prefix,
+        String parentField,
+        List<OcrDataField> ocrDataFields,
+        Map<String, Object> modifiedMap) {
+        addMappingsTo(parentField, getAddressMapping(prefix), modifiedMap, ocrDataFields);
+    }
 
+    /**
+     * All types of Address complex types (such as predefined in CCD: AddressUK, AddressGlobalUK and AddressGlobal
+     * and types defined in Divorce) do have address line 2.
+     *
+     * <p>More: https://tools.hmcts.net/confluence/display/RCCD/Address+global+complex+type
+     * */
+    private static ImmutableMap<String, String> getAddressMapping(String prefix) {
         String nestedFieldPrefix = StringUtils.capitalize(prefix + "Address");
+        Map<String, String> address = new HashMap<>();
 
-        addMappingsTo(
-            parentField,
-            ImmutableMap.of(
-                nestedFieldPrefix + "Line1", "AddressLine1",
-                nestedFieldPrefix + "County", "County",
-                nestedFieldPrefix + "Postcode", "PostCode",
-                nestedFieldPrefix + "Town", "PostTown",
-                nestedFieldPrefix + "Country", "Country"
-            ),
-            modifiedMap,
-            ocrDataFields
-        );
+        address.put(nestedFieldPrefix + "Line1", "AddressLine1");
+        address.put(nestedFieldPrefix + "Line2", "AddressLine2");
+        address.put(nestedFieldPrefix + "County", "County");
+        address.put(nestedFieldPrefix + "Postcode", "PostCode");
+        address.put(nestedFieldPrefix + "Town", "PostTown");
+        address.put(nestedFieldPrefix + "Country", "Country");
+
+        return ImmutableMap.copyOf(address);
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/bsp/common/mapper/AddressMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bsp/common/mapper/AddressMapperTest.java
@@ -15,6 +15,7 @@ import static uk.gov.hmcts.reform.bsp.common.mapper.AddressMapper.applyMappings;
 public class AddressMapperTest {
 
     public static final String LINE_1 = "102 Petty France";
+    public static final String LINE_2 = "6th floor";
     public static final String TOWN = "London";
     public static final String POSTCODE = "SW8 2PX";
     public static final String COUNTY = "Greater London";
@@ -24,6 +25,7 @@ public class AddressMapperTest {
     public void applyMappingsShouldMapAllFieldsWhenTheyAreProvided() {
         List<OcrDataField> input = asList(
             new OcrDataField("MyAddressLine1", LINE_1),
+            new OcrDataField("MyAddressLine2", LINE_2),
             new OcrDataField("MyAddressTown", TOWN),
             new OcrDataField("MyAddressPostcode", POSTCODE),
             new OcrDataField("MyAddressCounty", COUNTY),
@@ -36,8 +38,9 @@ public class AddressMapperTest {
 
         Map address = (Map)caseData.get("personalAddress");
 
-        assertThat(address.size(), is(5));
+        assertThat(address.size(), is(6));
         assertThat(address.get("AddressLine1"), is(LINE_1));
+        assertThat(address.get("AddressLine2"), is(LINE_2));
         assertThat(address.get("PostTown"), is(TOWN));
         assertThat(address.get("PostCode"), is(POSTCODE));
         assertThat(address.get("County"), is(COUNTY));

--- a/src/test/java/uk/gov/hmcts/reform/bsp/common/mapper/AddressMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bsp/common/mapper/AddressMapperTest.java
@@ -64,4 +64,27 @@ public class AddressMapperTest {
         assertThat(address.get("AddressLine1"), is(LINE_1));
         assertThat(address.get("Country"), is(COUNTRY));
     }
+
+    @Test
+    public void applyMappingsShouldMapOnlyNonNullValues() {
+        List<OcrDataField> input = asList(
+            new OcrDataField("MyAddressLine1", LINE_1),
+            new OcrDataField("MyAddressLine2", null),
+            new OcrDataField("MyAddressPostcode", ""),
+            new OcrDataField("MyAddressTown", " "),
+            new OcrDataField("MyAddressCountry", COUNTRY)
+        );
+
+        HashMap<String, Object> caseData = new HashMap<>();
+
+        applyMappings("my", "personalAddress", input, caseData);
+
+        Map<String, String> address = (Map)caseData.get("personalAddress");
+
+        assertThat(address.size(), is(4));
+        assertThat(address.get("AddressLine1"), is(LINE_1));
+        assertThat(address.get("Country"), is(COUNTRY));
+        assertThat(address.get("PostTown"), is(" "));
+        assertThat(address.get("PostCode"), is(""));
+    }
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/BSP-356


### Change description ###
added AddressLine2 key to address mapping as all complex types we are using have this field. 


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```

