### PR TITLE
Removing maven local

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,7 +52,6 @@ compileTestJava {
 }
 
 repositories {
-    mavenLocal()
     jcenter()
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ plugins {
 apply plugin: 'org.springframework.boot'
 
 group 'uk.gov.hmcts.reform'
-version '0.0.33'
+version '0.0.34'
 
 dependencyUpdates.resolutionStrategy = {
     componentSelection { rules ->


### PR DESCRIPTION
### Change description ###
Gradle advises against local repos. https://docs.gradle.org/current/userguide/declaring_repositories.html#sub:local-repos
The same effect can be achieved by using Composite builds (supported by IntelliJ and command-line)
![image](https://user-images.githubusercontent.com/21971276/79896778-ae752280-8400-11ea-9694-949b9863d9fb.png)
![image (1)](https://user-images.githubusercontent.com/21971276/79896797-b5039a00-8400-11ea-8825-8b36ad1720e4.png)


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x ] No
```

