### PR TITLE
DIV-6237: reverted to java 8

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -17,10 +17,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v1
-      - name: Set up JDK 11
+      - name: Set up JDK 1.8
         uses: actions/setup-java@v1
         with:
-          java-version: 11
+          java-version: 1.8
       - name: Build
         run: ./gradlew check
       - name: Check artifact can be released

--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ plugins {
 apply plugin: 'org.springframework.boot'
 
 group 'uk.gov.hmcts.reform'
-version '0.0.45'
+version '0.0.46'
 
 dependencyUpdates.resolutionStrategy = {
     componentSelection { rules ->
@@ -51,8 +51,8 @@ tasks.withType(Checkstyle).each { checkstyleTask ->
     }
 }
 
-sourceCompatibility = 11
-targetCompatibility = 11
+sourceCompatibility = 1.8
+targetCompatibility = 1.8
 
 compileJava {
     options.compilerArgs << '-parameters' << '-Xlint:deprecation'

--- a/src/main/java/uk/gov/hmcts/reform/bsp/common/model/document/CtscContactDetails.java
+++ b/src/main/java/uk/gov/hmcts/reform/bsp/common/model/document/CtscContactDetails.java
@@ -7,9 +7,9 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 
 @Data
-@JsonIgnoreProperties(ignoreUnknown = true)
 @Builder
 @EqualsAndHashCode
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class CtscContactDetails {
     @JsonProperty("serviceCentre")
     private String serviceCentre;


### PR DESCRIPTION
We couldn't use lib compiled in java 11 in project compiled in java 8.

When we migrate to java 11 in divorce-cos we can move back to 11.

Example of errors - see jenkins build:
https://github.com/hmcts/div-case-orchestration-service/pull/948